### PR TITLE
some small cleanups

### DIFF
--- a/boot/dboot.lua
+++ b/boot/dboot.lua
@@ -1,44 +1,43 @@
 --dawn default boot program
 --by dusk
 
+local function setboot()
+    write("Boot file path:")
+    local bootfileNew = read()
+    print("remove bootfile")
+    fs.delete("/boot/.bootfile")
+    print("copy from /etc/backup/")
+    fs.copy("/etc/backup/.bootfile", "/tmp/.bootfile")
+    print("open and write",bootfileNew,"to /tmp/.bootfile")
+    local tmpb = fs.open("/tmp/.bootfile","w")
+    tmpb.write(bootfileNew)
+    tmpb.close()
+    print("move to /boot/")
+    fs.move("/tmp/.bootfile", "/boot/.bootfile")
+end
+
+local function setbail()
+    write("bail file path:")
+    local bailfileNew = read()
+    print("remove bailto")
+    fs.delete("/boot/.bailto")
+    print("copy from /etc/backup/")
+    fs.copy("/etc/backup/.bailto", "/tmp/.bailto")
+    print("open and write",bailfileNew,"to /tmp/.bailto")
+    local tmpb = fs.open("/tmp/.bailto","w")
+    tmpb.write(bailfileNew)
+    tmpb.close()
+    print("move to /boot/")
+    fs.move("/tmp/.bailto" "/boot/.bailto")
+end
+
+local limitshell = {
+    [ "setboot" ] = setboot,
+    [ "setbail" ] = setbail,
+    [ "reboot" ] = os.reboot
+}
+
 local function run(a)
-
-    local function setboot()
-        write("Boot file path:")
-        local bootfileNew = read()
-        print("remove bootfile")
-        shell.run("rm /boot/.bootfile")
-        print("copy from /etc/backup/")
-        shell.run("copy /etc/backup/.bootfile /tmp/.bootfile")
-        print("open and write",bootfileNew,"to /tmp/.bootfile")
-        local tmpb = fs.open("/tmp/.bootfile","w")
-        tmpb.write(bootfileNew)
-        tmpb.close()
-        print("move to /boot/")
-        shell.run("move /tmp/.bootfile /boot/")
-    end
-
-    local function setbail()
-        write("bail file path:")
-        local bailfileNew = read()
-        print("remove bailto")
-        shell.run("rm /boot/.bailto")
-        print("copy from /etc/backup/")
-        shell.run("copy /etc/backup/.bailto /tmp/.bailto")
-        print("open and write",bailfileNew,"to /tmp/.bailto")
-        local tmpb = fs.open("/tmp/.bailto","w")
-        tmpb.write(bailfileNew)
-        tmpb.close()
-        print("move to /boot/")
-        shell.run("move /tmp/.bailto /boot/")
-    end
-
-    local limitshell = {
-        [ "setboot" ] = setboot,
-        [ "setbail" ] = setbail,
-        [ "reboot" ] = os.reboot
-    }
-
     for k,v in pairs(limitshell) do
         if a == k then
             v()

--- a/startup/ensurebase.lua
+++ b/startup/ensurebase.lua
@@ -38,10 +38,9 @@ local core = {
 
 for _,v in pairs(basefs) do
     if fs.exists(v) then
-        print(v,"exists")
+        print(v," exists")
     else
-        printError("/startup/ensurebase.lua:38:",v,"does not exist.")
-        error()
+        error(v.." does not exist.")
     end
 end
 
@@ -49,8 +48,7 @@ for _,v in pairs(core) do
     if fs.exists(v) then
         print(v,"exists")
     else
-        printError("/startup/ensurebase.lua:47:",v,"does not exist.")
-        error()
+        error(v.." does not exist.")
     end
 end
 


### PR DESCRIPTION
- using `printError` with line messages is kinda jank and unreliable - just giving `error` an error message is much simpler and you don't have to manually fiddle with line numbers every time you change something.
- calling e.g. `fs.delete("foo")` instead of `shell.run("rm foo")` is faster and simpler